### PR TITLE
Home vs ars results update

### DIFF
--- a/current_results.py
+++ b/current_results.py
@@ -1,4 +1,4 @@
-#revision 0.03
+#revision 0.04
 import sys
 import datetime
 current_time = str(datetime.datetime.now())
@@ -34,7 +34,7 @@ away_vs_tot = str('Tottenham Hotspur 0:0 Leicester City')#<-----------YET TO BE 
 away_vs_wat = str('Watford FC 0:0 Leicester City')#<-----------YET TO BE PLAYED
 away_vs_whu = str('West Ham United 0:0 Leicester City')#<-----------YET TO BE PLAYED
 away_vs_wol = str('Wolverhampton Wanderers 0:0 Leicester City')#<-----------YET TO BE PLAYED
-home_vs_ars = str('Leicester City 0:0 Arsenal FC') #<-----------YET TO BE PLAYED
+home_vs_ars = str('Leicester City 2:0 Arsenal FC')
 home_vs_ast = str('Leicester City 0:0 Aston Villa')#<-----------YET TO BE PLAYED
 home_vs_bha = str('Leicester City 0:0 Brighton Hove Albion')#<-----------YET TO BE PLAYED
 home_vs_bou = str('Leicester City 3:1 AFC Bournemouth')

--- a/current_results_version.py
+++ b/current_results_version.py
@@ -1,5 +1,5 @@
 import sys
-results_version = float(0.03)
+results_version = float(0.04)
 
 def current_results_version():
     print(results_version)

--- a/run.py
+++ b/run.py
@@ -134,6 +134,10 @@ def startuppage():
 def player_passed_close_page():
     print('Update tool has completed')
 
+def startupquery00fail():
+    print('Incorrect syntax, please try once more.')
+    startupquery00()
+
 def startupquery00():
     startquery = input('\nType "stats" for player statistics.\nType "fixtures" for the fixture list.'
                        '\nType "commands" for a list of other features or "exit" to close the program.'
@@ -152,6 +156,7 @@ def startupquery00():
         startupquery00()
     if (startquery == shut_down):
         sys.exit()
+    else: startupquery00fail()
 
 def list_of_commands():
     command_list = input('\nfixtures / stats / player/or/fixture version\n\nType "reset" to go back to the beginning\n').lower()

--- a/run.py
+++ b/run.py
@@ -17,6 +17,7 @@ results = str('scores')
 rst1 = str('reset')
 fx_version = str('fixture version') #version for fixture
 pl_version = str('player version') #version for player stats
+rs_version = str('results version') #version for results
 yes = str('y')
 no = str('n')
 shut_down = str('exit')
@@ -159,7 +160,7 @@ def startupquery00():
     else: startupquery00fail()
 
 def list_of_commands():
-    command_list = input('\nfixtures / stats / player/or/fixture version\n\nType "reset" to go back to the beginning\n').lower()
+    command_list = input('\nfixtures / stats / player/or/fixture/or/results version\n\nType "reset" to go back to the beginning\n').lower()
     if (command_list == fixtures):
         subprocess.call(['python', 'current_fixture_list.py']) #downloads the new fixture list
         list_of_commands()
@@ -176,6 +177,9 @@ def list_of_commands():
         list_of_commands()
     if (command_list == pl_version):
         print(float(player_stats_current_version))
+        list_of_commands()
+    if (command_list == rs_version):
+        print(float(results_list_current_version))
         list_of_commands()
     else: list_of_commands_failed_syntax()
 

--- a/update_table.txt
+++ b/update_table.txt
@@ -3,7 +3,7 @@
 	<body>
 		<main id="player_update_version">0.04</main>
 		
-		<h1 id="results_update_version">0.03</h1>
+		<h1 id="results_update_version">0.04</h1>
 		
 		<p id="fixture_update_version">0.08</p>
   	</body>


### PR DESCRIPTION
Results page has been updated after the 2-0 win over Arsenal.

User queries on run.py updated: Else loop placed on the initial query and a list version option under 'commands' for the current_results.py files.

